### PR TITLE
Change Github organisation to CCS

### DIFF
--- a/scripts/review-dependabot-prs.py
+++ b/scripts/review-dependabot-prs.py
@@ -68,7 +68,7 @@ def eligible_for_semiautomated_merge(pr):
 
 if __name__ == "__main__":
     github_repo_string = " ".join(
-        f"repo:alphagov/{repo}" for repo in get_digital_marketplace_repos()
+        f"repo:Crown-Commercial-Service/{repo}" for repo in get_digital_marketplace_repos()
     )
 
     output = subprocess.run(


### PR DESCRIPTION
It seems that `gh` doesn't follow the redirect for the repos we've moved from `alphagov` to `Crown-Commercial-Service` when using it like this. Update the org name so this script still works.