### PR TITLE
Generate email list for 'coming' email

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,12 +45,12 @@ importlib-metadata==1.5.0
     #   -c requirements.txt
     #   pluggy
     #   pytest
-ipython==7.12.0
-    # via -r requirements-dev.in
 ipython-genutils==0.2.0
     # via
     #   -r requirements-dev.in
     #   traitlets
+ipython==7.12.0
+    # via -r requirements-dev.in
 jedi==0.16.0
     # via ipython
 lxml==4.6.3
@@ -93,12 +93,12 @@ python-dateutil==2.8.2
     # via
     #   -c requirements.txt
     #   freezegun
+requests-mock==1.7.0
+    # via -r requirements-dev.in
 requests==2.25.1
     # via
     #   -c requirements.txt
     #   requests-mock
-requests-mock==1.7.0
-    # via -r requirements-dev.in
 six==1.14.0
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ itsdangerous==2.0.1
 
 digitalmarketplace-apiclient
 digitalmarketplace-content-loader
-digitalmarketplace-utils
+digitalmarketplace-utils>=59.2.0
 
 backoff==1.11.1
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ digitalmarketplace-apiclient==22.2.0
     # via -r requirements.in
 digitalmarketplace-content-loader==8.2.2
     # via -r requirements.in
-digitalmarketplace-utils==59.1.1
+digitalmarketplace-utils==59.2.0
     # via
     #   -r requirements.in
     #   digitalmarketplace-content-loader
@@ -46,6 +46,14 @@ docopt==0.6.2
     # via
     #   -r requirements.in
     #   notifications-python-client
+flask-gzip==0.2
+    # via digitalmarketplace-utils
+flask-login==0.5.0
+    # via digitalmarketplace-utils
+flask-session==0.3.2
+    # via digitalmarketplace-utils
+flask-wtf==0.14.3
+    # via digitalmarketplace-utils
 flask==1.0.4
     # via
     #   -r requirements.in
@@ -56,14 +64,6 @@ flask==1.0.4
     #   flask-session
     #   flask-wtf
     #   gds-metrics
-flask-gzip==0.2
-    # via digitalmarketplace-utils
-flask-login==0.5.0
-    # via digitalmarketplace-utils
-flask-session==0.3.2
-    # via digitalmarketplace-utils
-flask-wtf==0.14.3
-    # via digitalmarketplace-utils
 fleep==1.0.1
     # via digitalmarketplace-utils
 future==0.18.2

--- a/scripts/framework-applications/export-mailchimp-coming-emails.py
+++ b/scripts/framework-applications/export-mailchimp-coming-emails.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Get all the emails from mailchimp for people who've asked to be notified about new framework iterations.
+
+Usage:
+    /export-mailchimp-coming-emails.py <stage> <since> [--verbose]
+
+Parameters:
+    <stage>  Stage to target
+    <since>  The date when the previous framework closed for applications. In ISO format: YYYY-MM-DD
+"""
+import csv
+import logging
+import sys
+
+from dateutil.parser import isoparse
+from dmutils.email.dm_mailchimp import DMMailChimpClient
+from docopt import docopt
+
+sys.path.insert(0, ".")
+
+from dmscripts.helpers import logging_helpers
+from dmscripts.helpers.auth_helpers import get_mailchimp_credentials
+
+TEST_AUDIENCE_ID = "18fb1fa411"  # PREVIEW OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST
+PRODUCTION_AUDIENCE_ID = "7534b3e89a"  # Digital Marketplace - open for applications
+
+
+def output_emails_as_csv(email_addresses):
+    writer = csv.writer(sys.stdout, delimiter=",", quotechar='"')
+    writer.writerow(["email address"])
+    for email_address in email_addresses:
+        writer.writerow([email_address])
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+
+    logger = logging_helpers.configure_logger(
+        {"dmapiclient": logging.INFO}
+        if arguments["--verbose"]
+        else {"dmapiclient": logging.WARN}
+    )
+
+    stage = arguments["<stage>"]
+    (username, api_key) = get_mailchimp_credentials(stage)
+    dm_mailchimp_client = DMMailChimpClient(
+        username,
+        api_key,
+        logger,
+    )
+
+    audience_id = PRODUCTION_AUDIENCE_ID if stage == "production" else TEST_AUDIENCE_ID
+    since = isoparse(arguments["<since>"])
+    email_addresses = dm_mailchimp_client.get_email_addresses_from_list(
+        audience_id,
+        status="subscribed",
+        since_timestamp_opt=since.isoformat(),
+    )
+    output_emails_as_csv(email_addresses)

--- a/scripts/framework-applications/export-mailchimp-coming-emails.py
+++ b/scripts/framework-applications/export-mailchimp-coming-emails.py
@@ -3,24 +3,26 @@
 Get all the emails from mailchimp for people who've asked to be notified about new framework iterations.
 
 Usage:
-    /export-mailchimp-coming-emails.py <stage> <since> [--verbose]
+    /export-mailchimp-coming-emails.py <stage> <previous_framework> [--verbose]
 
 Parameters:
-    <stage>  Stage to target
-    <since>  The date when the previous framework closed for applications. In ISO format: YYYY-MM-DD
+    <stage>               Stage to target
+    <previous_framework>  The previous framework in this family
 """
 import csv
 import logging
 import sys
 
 from dateutil.parser import isoparse
+from dmapiclient import DataAPIClient
 from dmutils.email.dm_mailchimp import DMMailChimpClient
+from dmutils.env_helpers import get_api_endpoint_from_stage
 from docopt import docopt
 
 sys.path.insert(0, ".")
 
 from dmscripts.helpers import logging_helpers
-from dmscripts.helpers.auth_helpers import get_mailchimp_credentials
+from dmscripts.helpers.auth_helpers import get_mailchimp_credentials, get_auth_token
 
 TEST_AUDIENCE_ID = "18fb1fa411"  # PREVIEW OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST
 PRODUCTION_AUDIENCE_ID = "7534b3e89a"  # Digital Marketplace - open for applications
@@ -31,6 +33,14 @@ def output_emails_as_csv(email_addresses):
     writer.writerow(["email address"])
     for email_address in email_addresses:
         writer.writerow([email_address])
+
+
+def get_date_framework_closed(stage, framework_slug):
+    data_api_client = DataAPIClient(
+        get_api_endpoint_from_stage(stage), get_auth_token("api", stage)
+    )
+    previous_framework = data_api_client.get_framework(framework_slug)["frameworks"]
+    return isoparse(previous_framework["applicationsCloseAtUTC"])
 
 
 if __name__ == "__main__":
@@ -51,10 +61,11 @@ if __name__ == "__main__":
     )
 
     audience_id = PRODUCTION_AUDIENCE_ID if stage == "production" else TEST_AUDIENCE_ID
-    since = isoparse(arguments["<since>"])
     email_addresses = dm_mailchimp_client.get_email_addresses_from_list(
         audience_id,
         status="subscribed",
-        since_timestamp_opt=since.isoformat(),
+        since_timestamp_opt=get_date_framework_closed(
+            stage, arguments["<previous_framework>"]
+        ),
     )
     output_emails_as_csv(email_addresses)


### PR DESCRIPTION
https://trello.com/c/xkosxLyt/128-2-automatically-extract-the-correct-set-of-emails-from-mailchimp

We send an email 1-2 weeks before a new framework opens to let people know about the new framework: https://trello.com/c/qqyRSPut/21-announce-that-new-framework-is-coming-1-2-weeks-before. The process for sending this email is currently very manual (see linked Trello card). For DOS 5, we made a mistake during the manual process. We exported the wrong list, so didn't notify everyone we ought to. Create a script to get the list of email addresses. This should make the process considerably quicker, easier, and safer in future.

I've tested this on Preview - all looks correct. We'll need to update the documentation after this gets merged.

Relies on https://github.com/Crown-Commercial-Service/digitalmarketplace-utils/pull/689