### PR TITLE
Update GitHub org name

### DIFF
--- a/dmscripts/helpers/search_filters.py
+++ b/dmscripts/helpers/search_filters.py
@@ -5,7 +5,7 @@ from dmcontent.content_loader import ContentManifest
 
 
 # the following functions were copied from the buyer frontend with minor alterations
-# https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/a83163/app/main/presenters/search_presenters.py
+# https://github.com/Crown-Commercial-Service/digitalmarketplace-buyer-frontend/blob/a83163/app/main/presenters/search_presenters.py
 def sections_for_lot(lot_slug: str, manifest: ContentManifest, all_lots: List[dict]):
     if lot_slug == 'all':
         for lot_slug in [x["slug"] for x in all_lots]:
@@ -17,7 +17,7 @@ def sections_for_lot(lot_slug: str, manifest: ContentManifest, all_lots: List[di
 
 
 # the below functions were copied from buyer frontend, with modifications
-# https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/a83163/app/main/helpers/search_helpers.py#L180
+# https://github.com/Crown-Commercial-Service/digitalmarketplace-buyer-frontend/blob/a83163/app/main/helpers/search_helpers.py#L180
 def get_filter_value_from_question_option(option):
     return option.get("value", option.get("label", ""))
 

--- a/scripts/framework-applications/scan-g-cloud-services-for-bad-words.py
+++ b/scripts/framework-applications/scan-g-cloud-services-for-bad-words.py
@@ -2,8 +2,9 @@
 
 """
 This script will check all free-text fields in submitted G-Cloud services for "bad words", as defined in
-the file at <bad_words_path> (typically block-list.txt in https://github.com/Crown-Commercial-Service/digitalmarketplace-bad-words),
-and generate a CSV report of any bad word found.
+the file at <bad_words_path> (typically block-list.txt in
+https://github.com/Crown-Commercial-Service/digitalmarketplace-bad-words), and generate a CSV report of any bad word
+found.
 
 Use the --scan-drafts option to scan draft services (supplier must still have 'onFramework' set to True).
 

--- a/scripts/framework-applications/scan-g-cloud-services-for-bad-words.py
+++ b/scripts/framework-applications/scan-g-cloud-services-for-bad-words.py
@@ -2,7 +2,7 @@
 
 """
 This script will check all free-text fields in submitted G-Cloud services for "bad words", as defined in
-the file at <bad_words_path> (typically block-list.txt in https://github.com/alphagov/digitalmarketplace-bad-words),
+the file at <bad_words_path> (typically block-list.txt in https://github.com/Crown-Commercial-Service/digitalmarketplace-bad-words),
 and generate a CSV report of any bad word found.
 
 Use the --scan-drafts option to scan draft services (supplier must still have 'onFramework' set to True).

--- a/scripts/maintenance-mode-pr.sh
+++ b/scripts/maintenance-mode-pr.sh
@@ -28,7 +28,7 @@ fi
 function create_maintenance_mode_branch()
 {
     rm -rf digitalmarketplace-aws
-    git clone "https://${GITHUB_ACCESS_TOKEN}@github.com/alphagov/digitalmarketplace-aws.git"
+    git clone "https://${GITHUB_ACCESS_TOKEN}@github.com/Crown-Commercial-Service/digitalmarketplace-aws.git"
     cd digitalmarketplace-aws
     git checkout -b "${GIT_MAINTENANCE_MODE_BRANCH_NAME}"
 }
@@ -40,9 +40,9 @@ function commit_and_create_github_pr()
     git commit -a -m "$1" -m "$2"
     git push origin "${GIT_MAINTENANCE_MODE_BRANCH_NAME}"
     post_data="{\"title\": \"$1\", \"body\": \"$2\", \"base\": \"master\", \"head\": \"${GIT_MAINTENANCE_MODE_BRANCH_NAME}\"}"
-    response_data=$(curl -XPOST -H "Accept: application/vnd.github.v3.full+json" -d "$post_data" "https://${GITHUB_ACCESS_TOKEN}@api.github.com/repos/alphagov/digitalmarketplace-aws/pulls")
-    echo "Created PR#$(echo "${response_data}" | jq -crM '.number') on alphagov/digitalmarketplace-aws."
-    echo "https://www.github.com/alphagov/digitalmarketplace-aws/pull/$(echo "${response_data}" | jq -crM '.number')"
+    response_data=$(curl -XPOST -H "Accept: application/vnd.github.v3.full+json" -d "$post_data" "https://${GITHUB_ACCESS_TOKEN}@api.github.com/repos/Crown-Commercial-Service/digitalmarketplace-aws/pulls")
+    echo "Created PR#$(echo "${response_data}" | jq -crM '.number') on Crown-Commercial-Service/digitalmarketplace-aws."
+    echo "https://www.github.com/Crown-Commercial-Service/digitalmarketplace-aws/pull/$(echo "${response_data}" | jq -crM '.number')"
 }
 
 function set_maintenance_mode()

--- a/scripts/oneoff/add-external-collaborator.py
+++ b/scripts/oneoff/add-external-collaborator.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
                 "--silent",
                 "--method",
                 "PUT",
-                f"repos/alphagov/digitalmarketplace-credentials/collaborators/{username}",
+                f"repos/Crown-Commercial-Service/digitalmarketplace-credentials/collaborators/{username}",
             ],
             check=True,
         )

--- a/scripts/oneoff/add-licence-info-to-readme.sh
+++ b/scripts/oneoff/add-licence-info-to-readme.sh
@@ -30,9 +30,9 @@ function commit_and_create_github_pr() {
   git commit -a -m "$1" -m "$2"
   git push -q origin "${GIT_README_UPDATE_BRANCH_NAME}"
   post_data="{\"title\": \"$1\", \"body\": \"$2\", \"base\": \"master\", \"head\": \"${GIT_README_UPDATE_BRANCH_NAME}\"}"
-  response_data=$(curl -XPOST -H "Accept: application/vnd.github.v3.full+json" -d "$post_data" "https://${GITHUB_ACCESS_TOKEN}@api.github.com/repos/alphagov/${REPO_NAME}/pulls")
-  echo "Created PR#$(echo "${response_data}" | jq -crM '.number') on alphagov/${REPO_NAME}."
-  echo "https://www.github.com/alphagov/${REPO_NAME}/pull/$(echo "${response_data}" | jq -crM '.number')"
+  response_data=$(curl -XPOST -H "Accept: application/vnd.github.v3.full+json" -d "$post_data" "https://${GITHUB_ACCESS_TOKEN}@api.github.com/repos/Crown-Commercial-Service/${REPO_NAME}/pulls")
+  echo "Created PR#$(echo "${response_data}" | jq -crM '.number') on Crown-Commercial-Service/${REPO_NAME}."
+  echo "https://www.github.com/Crown-Commercial-Service/${REPO_NAME}/pull/$(echo "${response_data}" | jq -crM '.number')"
 }
 
 function add_licence_info() {

--- a/scripts/oneoff/inject-framework-dates.py
+++ b/scripts/oneoff/inject-framework-dates.py
@@ -18,7 +18,7 @@ from dmapiclient import DataAPIClient
 from dmscripts.helpers.auth_helpers import get_auth_token
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
-# Dates taken from https://github.com/alphagov/digitalmarketplace-frameworks/blob
+# Dates taken from https://github.com/Crown-Commercial-Service/digitalmarketplace-frameworks/blob
 # /e1f8e5c4a1a98d817e1bc9ff90ace85c1a0762c6/frameworks/<framework>/messages/dates.yml
 FRAMEWORKS_AND_DATES = {
     'digital-outcomes-and-specialists': {

--- a/scripts/rotate-api-tokens.sh
+++ b/scripts/rotate-api-tokens.sh
@@ -47,7 +47,7 @@ function get_jenkins_env_token_name() {
 
 function create_credentials_update_branch() {
   rm -rf digitalmarketplace-credentials
-  git clone "https://${GITHUB_ACCESS_TOKEN}@github.com/alphagov/digitalmarketplace-credentials.git"
+  git clone "https://${GITHUB_ACCESS_TOKEN}@github.com/Crown-Commercial-Service/digitalmarketplace-credentials.git"
   cd digitalmarketplace-credentials
   git checkout -b "${GIT_CREDS_UPDATE_BRANCH_NAME}"
 }
@@ -58,9 +58,9 @@ function commit_and_create_github_pr() {
   git commit -a -m "$1" -m "$2"
   git push -q origin "${GIT_CREDS_UPDATE_BRANCH_NAME}"
   post_data="{\"title\": \"$1\", \"body\": \"$2\", \"base\": \"master\", \"head\": \"${GIT_CREDS_UPDATE_BRANCH_NAME}\"}"
-  response_data=$(curl -XPOST -H "Accept: application/vnd.github.v3.full+json" -d "$post_data" "https://${GITHUB_ACCESS_TOKEN}@api.github.com/repos/alphagov/digitalmarketplace-credentials/pulls")
-  echo "Created PR#$(echo "${response_data}" | jq -crM '.number') on alphagov/digitalmarketplace-credentials."
-  echo "https://www.github.com/alphagov/digitalmarketplace-credentials/pull/$(echo "${response_data}" | jq -crM '.number')"
+  response_data=$(curl -XPOST -H "Accept: application/vnd.github.v3.full+json" -d "$post_data" "https://${GITHUB_ACCESS_TOKEN}@api.github.com/repos/Crown-Commercial-Service/digitalmarketplace-credentials/pulls")
+  echo "Created PR#$(echo "${response_data}" | jq -crM '.number') on Crown-Commercial-Service/digitalmarketplace-credentials."
+  echo "https://www.github.com/Crown-Commercial-Service/digitalmarketplace-credentials/pull/$(echo "${response_data}" | jq -crM '.number')"
 }
 
 function add_new_tokens() {

--- a/tests/test_notify_suppliers_whether_application_made_for_framework.py
+++ b/tests/test_notify_suppliers_whether_application_made_for_framework.py
@@ -34,7 +34,7 @@ class TestNotifySuppliersWhetherApplicationMade:
         ]
         self.data_api_client.export_users.return_value = {
             # This endpoint returns some unusually formatted keys :(
-            # See https://github.com/alphagov/digitalmarketplace-api/blob/6ad35e526fcf4d76320159a1a4ac97133a1ce13d/app/main/views/users.py#L417  # noqa
+            # See https://github.com/Crown-Commercial-Service/digitalmarketplace-api/blob/6ad35e526fcf4d76320159a1a4ac97133a1ce13d/app/main/views/users.py#L417  # noqa
             'users': [
                 {'supplier_id': 712345, 'email address': 'user1@example.com', 'application_status': 'no_application'},
                 {'supplier_id': 712346, 'email address': 'user2@example.com', 'application_status': 'application'},


### PR DESCRIPTION
https://trello.com/c/MYdNqOcQ/2331-remove-brett-%F0%9F%91%8B
https://trello.com/c/lvNKNOnS/2329-remove-alex-%F0%9F%91%8B

We're now on 'Crown-Commercial-Service' - not 'alphagov'. Update the scripts accordingly. This should allow us to rotate tokens once again - we're currently getting unexpected responses from the GitHub API because we're using the old organisation name (https://ci.marketplace.team/job/rotate-api-tokens/46/consoleFull).