### PR TITLE
Remove pip-tools from requirements

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,7 +1,5 @@
 -c requirements.txt
 
-pip-tools>5.0.0
-
 cram
 flake8
 freezegun

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,10 +20,6 @@ chardet==3.0.4
     # via
     #   -c requirements.txt
     #   requests
-click==7.0
-    # via
-    #   -c requirements.txt
-    #   pip-tools
 cram==0.7
     # via -r requirements-dev.in
 decorator==4.4.1
@@ -66,8 +62,6 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==5.5.0
-    # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
 prompt-toolkit==3.0.3
@@ -117,5 +111,4 @@ wcwidth==0.1.8
     #   pytest
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
 # setuptools


### PR DESCRIPTION
https://trello.com/c/2dP0Dfmr/2357-fix-pip-tools-catch-22

As instructed, I have removed `pip-tools` and then updated the requirements files