### PR TITLE
Update responsible security vulnerability disclosure to CCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ invoke freeze-requirements
 
 ## Contributing
 
-This repository is maintained by the Digital Marketplace team at the [Government Digital Service](https://github.com/alphagov).
+This repository is maintained by the Digital Marketplace team at the [Crown Commercial Service](https://github.com/Crown-Commercial-Service).
 
 If you have a suggestion for improvement, please raise an issue on this repo.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+Contact: cybersecurity@crowncommercial.gov.uk
+
+Policy: https://www.crowncommercial.gov.uk/vulnerability-disclosure-policy
+
+Acknowledgements: https://www.crowncommercial.gov.uk/vulnerability-disclosure-policy/acknowledgements
+
+Encryption: https://github.com/Crown-Commercial-Service/ccs-vulnerability-disclosure-policy/blob/main/vulnerability-disclosure-public-encryption.pub


### PR DESCRIPTION
https://trello.com/c/yXyu5sA6/180-update-links-for-reporting-security-vulnerabilities

Update responsible security vulnerability disclosure for repo now DM has transitioned to CCS