### PR TITLE
Add NFT to list to access api client shell

### DIFF
--- a/scripts/api-clients-shell.py
+++ b/scripts/api-clients-shell.py
@@ -50,6 +50,9 @@ def DMEnvironmentPrompt(stage: str, read_only: bool = False):
         "production": {
             "prompt": (Token.Generic.Error, "production"),
         },
+        "nft": {
+            "prompt": (Token.Generic, "nft"),
+        },
         "read_only": {
             "prompt": (Token.Generic.Strong, "ro"),
         },
@@ -94,7 +97,7 @@ class ReadOnlyDataAPIClient:
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('stage', default='development', help='The stage your clients should target',
-                        choices=['development', 'preview', 'staging', 'production'], nargs='?')
+                        choices=['development', 'preview', 'staging', 'production', 'nft'], nargs='?')
 
     parser.add_argument('--api-url', help='Override the implicit API URL', type=str)
     parser.add_argument('--api-token', help='Override for the API key (don\'t decrypt from dm-credentials)', type=str)


### PR DESCRIPTION
This will allow us to use the `api-clients-shell.py` script in the NFT environment.