### PR TITLE
Provide a good error message if gh is not installed

### DIFF
--- a/scripts/review-bot-prs.py
+++ b/scripts/review-bot-prs.py
@@ -87,8 +87,18 @@ def eligible_for_semiautomated_merge(pr):
     return True
 
 
+def check_gh_installed():
+    try:
+        subprocess.run(["which", "gh"], check=True)
+    except subprocess.CalledProcessError as e:
+        print("You are missing the `gh` CLI tool. Install it from https://github.com/cli/cli#installation")
+        raise e
+
+
 if __name__ == "__main__":
     arguments = docopt(__doc__)
+
+    check_gh_installed()
 
     BOT = 'snyk' if arguments['snyk'] else 'dependabot'
 


### PR DESCRIPTION
This has caught out a couple of people now. Provide a more useful error that should make it more obvious what one needs to do.

Example of output:

```
$ scripts/review-bot-prs.py dependabot
You are missing the `gh` CLI tool. Install it from https://github.com/cli/cli#installation
Traceback (most recent call last):
  File "/Users/benjamin.gill/code/digitalmarketplace-scripts/scripts/review-bot-prs.py", line 101, in <module>
    check_gh_installed()
  File "/Users/benjamin.gill/code/digitalmarketplace-scripts/scripts/review-bot-prs.py", line 95, in check_gh_installed
    raise e
  File "/Users/benjamin.gill/code/digitalmarketplace-scripts/scripts/review-bot-prs.py", line 92, in check_gh_installed
    subprocess.run(["which", "ghy"], check=True)
  File "/usr/local/Cellar/python@3.9/3.9.8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['which', 'gh']' returned non-zero exit status 1.
```