### PR TITLE
Send DOS6 coming email to more people

### DIFF
--- a/scripts/framework-applications/generate-email-list-for-coming.py
+++ b/scripts/framework-applications/generate-email-list-for-coming.py
@@ -5,7 +5,7 @@ Get the email addresses of everyone we will notify about a new framework coming.
 * all people who registered an interest since the given date
 
 Usage:
-    /generate-email-list-for-coming.py <stage> <notify_since_date> <previous_framework> [--verbose]
+    /generate-email-list-for-coming.py <stage> <notify_since_date> <previous_framework>... [--verbose]
 
 Parameters:
     <stage>               Stage to target
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     arguments = docopt(__doc__)
 
     stage = arguments["<stage>"]
-    previous_framework = arguments["<previous_framework>"]
+    previous_frameworks = arguments["<previous_framework>"]
     notify_since_date = parse_datetime(arguments["<notify_since_date>"])
     logger = logging_helpers.configure_logger(
         {"dmapiclient": logging.INFO}
@@ -78,6 +78,7 @@ if __name__ == "__main__":
     )
     existing_supplier_email_addresses = {
         user["email address"]
+        for previous_framework in previous_frameworks
         for user in data_api_client.export_users_iter(previous_framework)
     }
 


### PR DESCRIPTION
https://crowncommercial.zendesk.com/agent/tickets/32738

Following a review of the original list of emails for the DOS6 coming email, we've decided to expand the logic to include more suppliers and people. See commits for details.

I tested by running `scripts/framework-applications/generate-email-list-for-coming.py production 2019-10-01 digital-outcomes-and-specialists-4  digital-outcomes-and-specialists-5 > dos6-coming-email-list-preview-2.csv`. I can confirm that the output file now contains the two domains that David asked to ensure were included (see ticket).

I'd like to try to automate finding the `notify_since_date`. But I don't think that's essential and we're running out of time. So I think this is fine as-is, and I'll try to make it better if I have time later.