### PR TITLE
Email stats snapshot

### DIFF
--- a/scripts/framework-applications/snapshot-framework-stats.py
+++ b/scripts/framework-applications/snapshot-framework-stats.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-Fetches application stats for a given framework (suppliers, services and users) from the API.
-The response is stored in an audit event and, if an ouput file is supplied, saved to a JSON file.
+Fetch application stats for a given framework (suppliers, services and users) from the API.
+Store the response in an audit event. Save the stats to the output file, if supplied. Email the stats, if supplied with
+a Notify API key.
 
 Usage:
-    snapshot_framework_stats.py <stage> <framework_slug> [--outfile=filename]
+    snapshot_framework_stats.py <stage> <framework_slug> [--outfile=filename] [--notify=notify_api_key]
 
 Example:
     ./snapshot_framework_stats.py development g-cloud-12 --outfile=myfile.json
@@ -21,14 +22,18 @@ from dmapiclient.audit import AuditTypes
 
 sys.path.insert(0, '.')
 from dmscripts.helpers.auth_helpers import get_auth_token
+from dmscripts.helpers.email_helpers import scripts_notify_client
 from dmscripts.helpers.logging_helpers import configure_logger
 from dmutils.env_helpers import get_api_endpoint_from_stage
 
 
 logger = configure_logger()
 
+NOTIFY_TEMPLATE_ID = "493ede76-d9c8-40b8-b543-1127ccb60674"  # In the 'Digital Marketplace CCS' service
+STATS_EMAIL = "digitalmarketplace-stats@crowncommercial.gov.uk"
 
-def log_human_readable_stats(stats):
+
+def get_human_readable_stats(stats):
     total_applications = 0
     made_declaration = 0
     added_services = 0
@@ -48,6 +53,24 @@ def log_human_readable_stats(stats):
             else:
                 started += stat['count']
 
+    return (
+        started,
+        made_declaration,
+        added_services,
+        completed,
+        total_applications,
+    )
+
+
+def log_human_readable_stats(stats):
+    (
+        started,
+        made_declaration,
+        added_services,
+        completed,
+        total_applications,
+    ) = get_human_readable_stats(stats)
+
     logger.info("*********** STATS ***********")
     logger.info(f"Started: {started}")
     logger.info(f"Made declaration: {made_declaration}")
@@ -55,6 +78,29 @@ def log_human_readable_stats(stats):
     logger.info(f"Completed: {completed}")
     logger.info(f"Total applications: {total_applications}")
     logger.info("*****************************")
+
+
+def email_stats(stats, mail_client, framework_name):
+    (
+        started,
+        made_declaration,
+        added_services,
+        completed,
+        total_applications,
+    ) = get_human_readable_stats(stats)
+
+    mail_client.send_email(
+        STATS_EMAIL,
+        NOTIFY_TEMPLATE_ID,
+        personalisation={
+            "started_count": started,
+            "made_declaration_count": made_declaration,
+            "added_services_count": added_services,
+            "completed_count": completed,
+            "total_count": total_applications,
+            "framework_name": framework_name,
+        }
+    )
 
 
 def snapshot_framework_stats(client, framework_slug):
@@ -83,3 +129,8 @@ if __name__ == '__main__':
     if arguments['--outfile'] is not None:
         with open(arguments['--outfile'], 'w') as outfile:
             json.dump(stats, outfile)
+    if notify_api_key := arguments['--notify']:
+        framework_name = client.get_framework(arguments['<framework_slug>'])['frameworks']['name']
+        mail_client = scripts_notify_client(notify_api_key, logger=logger)
+
+        email_stats(stats, mail_client, framework_name)


### PR DESCRIPTION
We've not currently got a way to upload stats to Google Drive and recreating it looks to be slow. So instead enhance the snapshot script to it can send the stats in an email. It sends it to a Google Group in the CCS domain so that people who want can access them.

Notify template: https://www.notifications.service.gov.uk/services/a9333c2c-e3a5-4eb3-bb28-86f3920c1900/templates/493ede76-d9c8-40b8-b543-1127ccb60674

Cherry-pick of https://github.com/Brickendon-DMp1-5/digitalmarketplace-scripts/pull/51. We need the change in this repo because it's the one that the `ccsdigitalmarketplace/scripts` docker image is built from.