### PR TITLE
Perform service edit diffs the right way round

### DIFF
--- a/dmscripts/export_service_edits.py
+++ b/dmscripts/export_service_edits.py
@@ -91,7 +91,7 @@ def service_edit_diff(data_api_client, audit_event) -> str:
     new = data_api_client.get_archived_service(audit_event["data"]["newArchivedServiceId"])
     old = data_api_client.get_archived_service(audit_event["data"]["oldArchivedServiceId"])
 
-    return diff_archived_services(new, old)
+    return diff_archived_services(old, new)
 
 
 def write_service_edits_csv(f, audit_events, data_api_client, *, include_diffs=True):

--- a/dmscripts/export_service_edits.py
+++ b/dmscripts/export_service_edits.py
@@ -48,36 +48,36 @@ def find_service_edits(
     return audit_events
 
 
-def diff_archived_services(a: dict, b: dict) -> str:
-    if "services" in a:
-        a = a["services"]
-    if "services" in b:
-        b = b["services"]
-    if not (a["frameworkFamily"] == b["frameworkFamily"] and a["lot"] == b["lot"]):
+def diff_archived_services(old: dict, new: dict) -> str:
+    if "services" in old:
+        old = old["services"]
+    if "services" in new:
+        new = new["services"]
+    if not (old["frameworkFamily"] == new["frameworkFamily"] and old["lot"] == new["lot"]):
         raise ValueError("archived services to compare must be from same framework family and lot")
 
-    assert a.keys() == b.keys()
+    assert old.keys() == new.keys()
 
-    def do_diff(a, b, key) -> str:
-        assert type(a) == type(b)
-        assert a != b
-        if isinstance(a, list):
+    def do_diff(old, new, key) -> str:
+        assert type(old) == type(new)
+        assert old != new
+        if isinstance(old, list):
             addnewlines = lambda l: list(map(lambda s: s + "\n", l))  # noqa: E731
-            return "".join(difflib.Differ().compare(addnewlines(a), addnewlines(b)))
-        elif isinstance(a, str):
+            return "".join(difflib.Differ().compare(addnewlines(old), addnewlines(new)))
+        elif isinstance(old, str):
             addnewline = lambda s: s + "\n" if not s.endswith("\n") else s  # noqa: E731
             return "".join(difflib.Differ().compare(
-                addnewline(a).splitlines(keepends=True),
-                addnewline(b).splitlines(keepends=True)
+                addnewline(old).splitlines(keepends=True),
+                addnewline(new).splitlines(keepends=True)
             ))
         else:
-            raise TypeError(f"cannot compare type '{type(a)}' at '{key}'")
+            raise TypeError(f"cannot compare type '{type(old)}' at '{key}'")
 
     changes = (
         "\n\n".join(
-            f"{k}:\n{do_diff(a[k], b[k], k)}"
-            for k in a
-            if a[k] != b[k]
+            f"{k}:\n{do_diff(old[k], new[k], k)}"
+            for k in old
+            if old[k] != new[k]
             and k not in ("links", "updatedAt")
         )
     )

--- a/tests/test_export_service_edits.py
+++ b/tests/test_export_service_edits.py
@@ -9,13 +9,13 @@ class TestArchivedServiceDiff:
         new_service = {"frameworkFamily": "foo", "lot": "bar"}
         old_service = {"frameworkFamily": "foo", "lot": "bar"}
 
-        assert diff_archived_services(new_service, old_service) == ""
+        assert diff_archived_services(old_service, new_service) == ""
 
     def test_diff_string_change(self):
         new_service = {"frameworkFamily": "foo", "lot": "bar", "key": "new value"}
         old_service = {"frameworkFamily": "foo", "lot": "bar", "key": "value"}
 
-        assert diff_archived_services(new_service, old_service) == """key:
+        assert diff_archived_services(old_service, new_service) == """key:
 - value
 + new value
 ? ++++

--- a/tests/test_export_service_edits.py
+++ b/tests/test_export_service_edits.py
@@ -1,0 +1,42 @@
+from dmapiclient import DataAPIClient
+from unittest import mock
+
+from dmscripts.export_service_edits import diff_archived_services, service_edit_diff
+
+
+class TestArchivedServiceDiff:
+    def test_no_content(self):
+        new_service = {"frameworkFamily": "foo", "lot": "bar"}
+        old_service = {"frameworkFamily": "foo", "lot": "bar"}
+
+        assert diff_archived_services(new_service, old_service) == ""
+
+    def test_diff_string_change(self):
+        new_service = {"frameworkFamily": "foo", "lot": "bar", "key": "new value"}
+        old_service = {"frameworkFamily": "foo", "lot": "bar", "key": "value"}
+
+        assert diff_archived_services(new_service, old_service) == """key:
+- value
++ new value
+? ++++
+"""
+
+
+class TestServiceEditDiff:
+    def test_diff(self):
+        data_api_client = mock.Mock(autospec=DataAPIClient)
+        data_api_client.get_archived_service.side_effect = [
+            {"frameworkFamily": "foo", "lot": "bar", "key": "new value"},
+            {"frameworkFamily": "foo", "lot": "bar", "key": "value"},
+        ]
+
+        audit_event = {
+            "type": "update_service",
+            "data": {"newArchivedServiceId": 1, "oldArchivedServiceId": 2}
+        }
+        assert service_edit_diff(data_api_client, audit_event) == """key:
+- value
++ new value
+? ++++
+"""
+        data_api_client.assert_has_calls([mock.call.get_archived_service(1), mock.call.get_archived_service(2)])


### PR DESCRIPTION
Thanks to some unclear naming, we were previously producing a diff of new to old. We actually wanted old to new.

Add tests that prove that the diff is now correct. Also rename parameters to make usage more obvious.

Discovered during https://crowncommercial.zendesk.com/agent/tickets/35580, but only tangentially related.