### PR TITLE
Add support for diffs with different keys

### DIFF
--- a/dmscripts/export_service_edits.py
+++ b/dmscripts/export_service_edits.py
@@ -48,6 +48,23 @@ def find_service_edits(
     return audit_events
 
 
+def add_defaults_for_keys(old: dict, new: dict):
+    """
+    Users can add/remove answers to optional questions. Add defaults so we can diff them.
+    """
+    for new_key in new.keys() - old.keys():
+        if isinstance(new[new_key], list):
+            old[new_key] = []
+        else:
+            old[new_key] = ""
+
+    for old_key in old.keys() - new.keys():
+        if isinstance(old[old_key], list):
+            new[old_key] = []
+        else:
+            new[old_key] = ""
+
+
 def diff_archived_services(old: dict, new: dict) -> str:
     if "services" in old:
         old = old["services"]
@@ -56,7 +73,7 @@ def diff_archived_services(old: dict, new: dict) -> str:
     if not (old["frameworkFamily"] == new["frameworkFamily"] and old["lot"] == new["lot"]):
         raise ValueError("archived services to compare must be from same framework family and lot")
 
-    assert old.keys() == new.keys()
+    add_defaults_for_keys(old, new)
 
     def do_diff(old, new, key) -> str:
         assert type(old) == type(new)

--- a/tests/test_export_service_edits.py
+++ b/tests/test_export_service_edits.py
@@ -31,6 +31,40 @@ class TestArchivedServiceDiff:
 ? ++++
 """
 
+    def test_diff_new_string_key(self):
+        new_service = {"frameworkFamily": "foo", "lot": "bar", "key": "new value"}
+        old_service = {"frameworkFamily": "foo", "lot": "bar"}
+
+        assert diff_archived_services(old_service, new_service) == """key:
+- 
++ new value
+"""  # noqa: W291
+
+    def test_diff_new_list_key(self):
+        new_service = {"frameworkFamily": "foo", "lot": "bar", "key": ["new value"]}
+        old_service = {"frameworkFamily": "foo", "lot": "bar"}
+
+        assert diff_archived_services(old_service, new_service) == """key:
++ new value
+"""
+
+    def test_diff_old_string_key(self):
+        new_service = {"frameworkFamily": "foo", "lot": "bar"}
+        old_service = {"frameworkFamily": "foo", "lot": "bar", "key": "old value"}
+
+        assert diff_archived_services(old_service, new_service) == """key:
+- old value
++ 
+"""  # noqa: W291
+
+    def test_diff_old_list_key(self):
+        new_service = {"frameworkFamily": "foo", "lot": "bar"}
+        old_service = {"frameworkFamily": "foo", "lot": "bar", "key": ["old value"]}
+
+        assert diff_archived_services(old_service, new_service) == """key:
+- old value
+"""
+
 
 class TestServiceEditDiff:
     def test_diff(self):

--- a/tests/test_export_service_edits.py
+++ b/tests/test_export_service_edits.py
@@ -21,6 +21,16 @@ class TestArchivedServiceDiff:
 ? ++++
 """
 
+    def test_diff_list_change(self):
+        new_service = {"frameworkFamily": "foo", "lot": "bar", "key": ["new value"]}
+        old_service = {"frameworkFamily": "foo", "lot": "bar", "key": ["value"]}
+
+        assert diff_archived_services(old_service, new_service) == """key:
+- value
++ new value
+? ++++
+"""
+
 
 class TestServiceEditDiff:
     def test_diff(self):


### PR DESCRIPTION
A fix for a bug discovered during https://crowncommercial.zendesk.com/agent/tickets/35580

It is valid for the keys to change - users can add/remove answers to optional questions. Since we're getting the data from the database, I think we can be confident that any such changes are valid.

Add tests to check that it's working.