### PR TITLE
Remove security policy from repo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,0 @@
-Contact: cybersecurity@crowncommercial.gov.uk
-
-Policy: https://www.crowncommercial.gov.uk/vulnerability-disclosure-policy
-
-Acknowledgements: https://www.crowncommercial.gov.uk/vulnerability-disclosure-policy/acknowledgements
-
-Encryption: https://github.com/Crown-Commercial-Service/ccs-vulnerability-disclosure-policy/blob/main/vulnerability-disclosure-public-encryption.pub


### PR DESCRIPTION
Some of the links are outdated and broken. Use the default org-wide policy instead that has the correct links (https://github.com/Crown-Commercial-Service/.github/blob/main/SECURITY.md).
