### PR TITLE
Get more PRs to review

### DIFF
--- a/scripts/review-bot-prs.py
+++ b/scripts/review-bot-prs.py
@@ -75,15 +75,13 @@ def eligible_for_semiautomated_merge(pr):
     if pr["mergeable"] != "MERGEABLE":
         print(f'Wrong mergeable: {pr["mergeable"]}')
         return False
-    if not pr["statusCheckRollup"]:
-        print(f'Wrong statusCheckRollup: {pr["statusCheckRollup"]}')
-        return False
-    unsuccessful_checks = [
-        check for check in pr["statusCheckRollup"] if not is_check_successful(check)
-    ]
-    if unsuccessful_checks:
-        print(f"Unsuccessful checks: {unsuccessful_checks}")
-        return False
+    if pr["statusCheckRollup"]:
+        unsuccessful_checks = [
+            check for check in pr["statusCheckRollup"] if not is_check_successful(check)
+        ]
+        if unsuccessful_checks:
+            print(f"Unsuccessful checks: {unsuccessful_checks}")
+            return False
     return True
 
 


### PR DESCRIPTION
Recently, I've found that the script has not picked up Dependabot PRs in some repos. I suspect this is because either the number of PRs or the number of repos is too large. Work around this by running the search indivually for each repo, to guarantee we get all the PRs. It makes the script a bit slower to run, but more comprehensive.

Also, some repos have no status checks. We still want to be able to review and merge PRs for those repos.