### PR TITLE
Upload approved service edit report to S3 and send email

### DIFF
--- a/dmscripts/helpers/auth_helpers.py
+++ b/dmscripts/helpers/auth_helpers.py
@@ -59,15 +59,14 @@ def get_jenkins_env_variable_from_credentials(env_var_dot_path, require_jenkins_
     return _get_nested_value(creds_json, env_var_dot_path.split('.'))
 
 
-def get_jenkins_env_variable(jenkins_var_name):
+def get_jenkins_env_variable(jenkins_var_name, require_jenkins_user=True):
     # Check the local env first, otherwise decrypt from credentials
     value = os.environ.get(jenkins_var_name)
 
     if not value:
-        # Only allow Jenkins users to decrypt from credentials for now
         value = get_jenkins_env_variable_from_credentials(
             "jenkins_env_variables.{}".format(jenkins_var_name),
-            require_jenkins_user=True
+            require_jenkins_user=require_jenkins_user
         )
 
     return value


### PR DESCRIPTION
https://trello.com/c/F0h3RRkV/2494-send-ccs-list-of-approved-service-edits-for-month-past

We've currently got a manual process to create the report and email it to a particular category admin once a month. I'm starting to get bored of this, so would like to automate it. Start uploading the report to S3 and sending an email to notify people that the report is available. I plan to set the DMP team as admins of the group, and add the current admin recipient as a member.

You can see the (successful) result of my testing in https://groups.google.com/a/crowncommercial.gov.uk/g/digitalmarketplace-service-edit-reports. The Notify template is: https://www.notifications.service.gov.uk/services/95316ff0-e555-462d-a6e7-95d26fbfd091/templates/fe4b0ac2-c25f-4b02-a72d-0d5b19819d74

Once this is merged, and [the accompanying admin-frontend change](https://github.com/Crown-Commercial-Service/digitalmarketplace-admin-frontend/pull/867) deployed to prod, we can add a monthly Jenkins job to fire off this script.

