### PR TITLE
Fix export briefs script for digital outcomes

### DIFF
--- a/scripts/oneoff/export_brief_responses.py
+++ b/scripts/oneoff/export_brief_responses.py
@@ -26,18 +26,29 @@ if __name__ == '__main__':
     framework = arguments['<framework>']
 
     data_api_client = DataAPIClient(get_api_endpoint_from_stage(stage), get_auth_token('api', stage))
-    filename = f'{framework}-brief-responses.csv'
+    filename = f'data/{framework}-brief-responses.csv'
 
-    def get_iterator():
+    def get_iterator(brief_id):
         # The default iterator does not include draft responses
-        return chain(data_api_client.find_brief_responses_iter(framework=framework),
-                     data_api_client.find_brief_responses_iter(framework=framework, status='draft'))
+        return chain(data_api_client.find_brief_responses_iter(brief_id=brief_id, framework=framework),
+                     data_api_client.find_brief_responses_iter(brief_id=brief_id, framework=framework, status='draft'))
 
     with open(filename, 'w') as csvfile:
         fieldnames = ['briefId', 'status', 'supplierId', 'createdAt', 'submittedAt']
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
-        for brief_response in get_iterator():
-            writer.writerow({field: brief_response.get(field) for field in fieldnames})
 
+        total_number_of_briefs = data_api_client.find_briefs(framework=framework)['meta']['total']
+        count = 0
+
+        for brief in data_api_client.find_briefs_iter(framework=framework):
+            count += 1
+            brief_id = brief['id']
+
+            for brief_response in get_iterator(brief_id):
+                writer.writerow({field: brief_response.get(field) for field in fieldnames})
+
+            print(f"Briefs exported: {count:04d}/{total_number_of_briefs}", end='\r')
+
+    print(f"Briefs exported: {count}/{total_number_of_briefs}")
     print(f"Outputted {filename}")


### PR DESCRIPTION
For whatever reason, if you don't put in the brief ID when trying to get the brief responses, you can get messed up brief response.

I've changed this script to get the brief response for each brief (rather than just get all the brief response).

Although this is much slower, it does produce accurate data at the end.